### PR TITLE
Pass request object to key def

### DIFF
--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -43,7 +43,7 @@ def get_upload_params(request):
         return HttpResponse(data, content_type="application/json", status=400)
 
     if hasattr(key, '__call__'):
-        key = key(filename)
+        key = key(request)
     elif key == '/':
         key = '${filename}'
     else:

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -18,6 +18,7 @@ def get_upload_params(request):
         return HttpResponse(data, content_type="application/json", status=400)
 
     key = dest.get('key')
+    key_receives_request = dest.get('key_receives_request')
     auth = dest.get('auth')
     allowed = dest.get('allowed')
     acl = dest.get('acl')
@@ -43,7 +44,10 @@ def get_upload_params(request):
         return HttpResponse(data, content_type="application/json", status=400)
 
     if hasattr(key, '__call__'):
-        key = key(request)
+        if key_receives_request:
+            key = key(request)
+        else:
+            key = key(filename)
     elif key == '/':
         key = '${filename}'
     else:


### PR DESCRIPTION
@eman, the change I made was to allow another setting for an `s3destination` that designates to pass the request object to the `key` def, instead of `filename`.  If the setting is true, the request object is passed.